### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ launching:
 | card_game | ~5s            | < 500M             |
 | ltp       | ~5s            | < 500M             |
 | os        | ~5s            | < 500M             |
-| kd        | ~5s            | < 500M             |
+| kg        | ~5s            | < 500M             |
 
 ## References
 


### PR DESCRIPTION
The correct abbreviation is "kg". It stands for "knowledge graph". The "kd" is a typo.