### PR TITLE
Fixed terminal output parsing

### DIFF
--- a/src/server/tasks/os_interaction/task.py
+++ b/src/server/tasks/os_interaction/task.py
@@ -78,6 +78,21 @@ class Container:
                 break
             except socket.timeout:
                 break
+
+        # Clean up the output by removing terminal control sequences, removes escape sequences starting with
+        # ESC (0x1b), followed by...
+        # ... any characters, an '@' character, any characters, ending with '#' or '$'
+        output = re.sub(b"\x1b.+@.+[#|$] ", b'', output)
+        # ... '[' and any combination of digits and semicolons, ending with a letter (a-z or A-Z)
+        output = re.sub(b'\x1b\\[[0-9;]*[a-zA-Z]', b'', output)
+        # ... ']' and any digits, a semicolon, any characters except BEL (0x07), and ending with BEL
+        output = re.sub(b'\x1b\\][0-9]*;[^\x07]*\x07', b'', output)
+        # ... '[?2004' and either 'h' or 'l'
+        output = re.sub(b'\x1b\[\?2004[hl]', b'', output)
+
+        # Remove BEL characters (0x07)
+        output = re.sub(b'\x07', b'', output)
+
         return DummyOutput(0, output)
 
     def execute_independent(self, command, *params):


### PR DESCRIPTION
Currently the output parsing from the terminal breaks when it first sees a escape symbol however it appends the whole package received from the socket, which does not necessarily correspond to a line in the terminal (if the command was run by a human). As an example:

Before the agent receives
"The output of the OS: The output of the OS:\n\n10\n[?2004h]0;root@e88175735799:/root@e88175735799:/# [K"

Now after this fix the agent receives
"The output of the OS: 10"