### PR TITLE
Fixed hanging bash commands from agent in os-task

### DIFF
--- a/src/server/tasks/os_interaction/task.py
+++ b/src/server/tasks/os_interaction/task.py
@@ -5,6 +5,7 @@ import os
 import re
 import socket
 import struct
+import time
 from typing import List, Dict, Any, Tuple
 
 import docker
@@ -62,8 +63,15 @@ class Container:
         data = self.sock.recv(8)
         _, n = struct.unpack(">BxxxL", data)
         _ = self.sock.recv(n)
+
+        time_limit = 30  # seconds
+        start_time = time.time()
+
         output = b""
         while True:
+            if time.time() - start_time > time_limit:
+                print(f"Time limit reached, breaking out of the loop. Command was: `{command}`")
+                break
             try:
                 data = self.sock.recv(8)
                 # print(data)


### PR DESCRIPTION
If the agent puts out a command like
    'while true; do ls /root; sleep 1; done'
it will loop while also putting out an output (meaning the socket doesn't timeout) so I've added a 30s cutoff. Without this it eventually fails but counts as an incomplete task rather than just a fail so it stops any of the overall stats working. With this fix the model will receive any output from the terminal up to this time cutoff.

There are other ways to address this problem (such as raising/catching an error instead of allowing the conversation to continue), please let me know if you think a different approach is better.